### PR TITLE
Fix notify workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -47,6 +47,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/post-to-twitter/requirements.txt
+          pip install -r scripts/post-to-telegram/requirements.txt
+
       # Check out the generated JSON file and put it on the current workspace
       # and set the variable json-post with the filename to be used for other
       # scripts

--- a/scripts/post-to-telegram/main.py
+++ b/scripts/post-to-telegram/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import sys
 import json
 import os

--- a/scripts/post-to-twitter/main.py
+++ b/scripts/post-to-twitter/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import re
 import sys


### PR DESCRIPTION
This PR fixes #40 setting up a correct Python 3.8 environment to run scripts on the `notify` step.