### PR TITLE
Use double quotes for the hashtags field

### DIFF
--- a/scripts/create-content/main.py
+++ b/scripts/create-content/main.py
@@ -64,15 +64,14 @@ def main(filename):
     url = body.splitlines()[0].replace("url: ", "")
     content += "link: %s\n" % url
 
-    if not "hashtags:" in body.splitlines()[1]:
+    if "hashtags:" not in body.splitlines()[1]:
         description = "\n".join(body.splitlines()[2:])
         content += "---\n%s\n" % description
     else:
-        hashtags = body.splitlines()[1].replace("hashtags: ","")
+        hashtags = body.splitlines()[1].replace("hashtags: ", "")
         content += "hashtags: %s\n" % hashtags
         description = "\n".join(body.splitlines()[3:])
         content += "---\n%s\n" % description
-
 
     post_filename = slugify(created_at, title)
     print(post_filename)

--- a/scripts/create-content/main.py
+++ b/scripts/create-content/main.py
@@ -69,7 +69,7 @@ def main(filename):
         content += "---\n%s\n" % description
     else:
         hashtags = body.splitlines()[1].replace("hashtags: ", "")
-        content += "hashtags: %s\n" % hashtags
+        content += 'hashtags: "%s"\n' % hashtags
         description = "\n".join(body.splitlines()[3:])
         content += "---\n%s\n" % description
 

--- a/scripts/create-content/test_main.py
+++ b/scripts/create-content/test_main.py
@@ -65,7 +65,7 @@ date: 2020-09-12T11:19:56Z
 github_username: pabluk
 twitter_username: pabluk
 link: https://example.com
-hashtags: #hash1,#hash2
+hashtags: "#hash1,#hash2"
 ---
 Markdown content...
 


### PR DESCRIPTION
Using double quotes for the `hashtags` field to avoid having hashtags being handled as a Markdown comment.

C.f: #42 