### PR TITLE
Use full commit SHA for actions-gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Deploy
         id: pages
-        uses: peaceiris/actions-gh-pages@7e55c73 #514
+        uses: peaceiris/actions-gh-pages@7e55c73ee896b01b8b8668370794b96f1bc9c759 #514
         if: github.ref == 'refs/heads/main' # avoid publishing other branches
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As described on #67, the short commit SHA format was deprecated on Feb 15th, so this change only replace the short by the full commit hash format on .github/workflows/gh-pages.yml.