### PR TITLE
Add a new rule for the slugify function

### DIFF
--- a/scripts/create-content/main.py
+++ b/scripts/create-content/main.py
@@ -19,6 +19,7 @@ def slugify(date, title):
     slug = slug.replace("%", "")
     slug = slug.replace("—", "")
     slug = slug.replace("…", "")
+    slug = slug.replace(",", "")
 
     # Remove leading, trailing and duplicated whitespaces
     slug = " ".join(slug.split())

--- a/scripts/create-content/test_main.py
+++ b/scripts/create-content/test_main.py
@@ -50,6 +50,13 @@ class TestSlugyFunction(unittest.TestCase):
         output = slugify(date, title)
         self.assertEqual(expected, output)
 
+    def test_comma_punctuation(self):
+        date = "2021-03-09"
+        title = "Everything is broken, and it’s okay"
+        expected = "content/links/2021-03-09-everything-is-broken-and-its-okay.md"
+        output = slugify(date, title)
+        self.assertEqual(expected, output)
+
 
 class TestMain(unittest.TestCase):
     @mock.patch("sys.stdout", new_callable=StringIO)


### PR DESCRIPTION
Fix the case when there are commas on titles and they need to be removed for filenames and URLs.

For example the title `"Everything is broken, and it’s okay"` will be translated to:
```
content/links/2021-03-09-everything-is-broken-and-its-okay.md
```
instead of:

```
content/links/2021-03-09-everything-is-broken,-and-its-okay.md
```
